### PR TITLE
feat(issue-57): 번역 결과 포맷팅 기능 구현

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,6 +137,24 @@ def clear_inputs() -> None:
     st.session_state.translation_result = None
 
 
+def format_translation_result(text: str) -> str:
+    """번역 결과의 포맷을 보존합니다.
+
+    Markdown에서 줄바꿈을 올바르게 표시하기 위해
+    각 줄 끝에 두 개의 공백을 추가합니다.
+
+    Args:
+        text: 원본 텍스트
+
+    Returns:
+        포맷이 보존된 텍스트
+    """
+    # 각 줄 끝에 두 공백 추가 (Markdown 줄바꿈 규칙)
+    lines = text.split('\n')
+    formatted_lines = [line + '  ' if line.strip() else line for line in lines]
+    return '\n'.join(formatted_lines)
+
+
 # ============================================================================
 # Configuration Functions (설정 및 초기화)
 # ============================================================================
@@ -158,6 +176,8 @@ def initialize_session_state() -> None:
         st.session_state.input_text = ""
     if 'translation_result' not in st.session_state:
         st.session_state.translation_result = None
+    if 'preserve_format' not in st.session_state:
+        st.session_state.preserve_format = True
 
 
 def setup_api_client() -> tuple[Any, Literal["openai", "azure"]]:
@@ -241,6 +261,15 @@ def setup_sidebar(provider: Literal["openai", "azure"]) -> tuple[str, dict[str, 
     # Provider 정보 표시
     provider_display = "🔵 OpenAI" if provider == "openai" else "🟢 Azure OpenAI"
     st.sidebar.markdown(f"**Provider:** {provider_display}")
+    st.sidebar.markdown("---")
+
+    # 포맷 유지 옵션
+    st.sidebar.checkbox(
+        "📝 포맷 유지",
+        value=True,
+        key="preserve_format",
+        help="번역 결과의 줄바꿈과 들여쓰기를 보존합니다."
+    )
     st.sidebar.markdown("---")
 
     if provider == "azure":
@@ -425,7 +454,12 @@ def render_translation_result() -> None:
                 create_dual_copy_buttons(result, "translation"),
                 height=60
             )
-            st.markdown(result)
+            # 포맷 유지 옵션에 따라 표시
+            if st.session_state.preserve_format:
+                formatted_result = format_translation_result(result)
+                st.markdown(formatted_result)
+            else:
+                st.markdown(result)
 
         with tab2:
             # Markdown 원본 복사 버튼

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,118 @@
-"""app.py setup_sidebar() 함수 테스트"""
+"""app.py 함수 테스트"""
 import pytest
 from unittest.mock import Mock, patch
+
+
+class TestFormatTranslationResult:
+    """format_translation_result() 함수 테스트"""
+
+    def test_single_line_with_content(self):
+        """한 줄 텍스트에 두 공백 추가"""
+        from app import format_translation_result
+
+        text = "Hello World"
+        result = format_translation_result(text)
+
+        assert result == "Hello World  "
+
+    def test_multiple_lines_with_content(self):
+        """여러 줄 텍스트의 각 줄에 두 공백 추가"""
+        from app import format_translation_result
+
+        text = "Line 1\nLine 2\nLine 3"
+        result = format_translation_result(text)
+
+        expected = "Line 1  \nLine 2  \nLine 3  "
+        assert result == expected
+
+    def test_empty_lines_preserved(self):
+        """빈 줄은 공백 없이 보존"""
+        from app import format_translation_result
+
+        text = "Line 1\n\nLine 2"
+        result = format_translation_result(text)
+
+        expected = "Line 1  \n\nLine 2  "
+        assert result == expected
+
+    def test_whitespace_only_lines(self):
+        """공백만 있는 줄은 두 공백 추가하지 않음"""
+        from app import format_translation_result
+
+        text = "Line 1\n   \nLine 2"
+        result = format_translation_result(text)
+
+        expected = "Line 1  \n   \nLine 2  "
+        assert result == expected
+
+    def test_mixed_content_and_empty_lines(self):
+        """콘텐츠 줄과 빈 줄이 혼합된 경우"""
+        from app import format_translation_result
+
+        text = "Paragraph 1\n\nParagraph 2\n  \nParagraph 3"
+        result = format_translation_result(text)
+
+        expected = "Paragraph 1  \n\nParagraph 2  \n  \nParagraph 3  "
+        assert result == expected
+
+    def test_trailing_newline(self):
+        """끝에 개행이 있는 경우"""
+        from app import format_translation_result
+
+        text = "Line 1\nLine 2\n"
+        result = format_translation_result(text)
+
+        expected = "Line 1  \nLine 2  \n"
+        assert result == expected
+
+    def test_indented_lines(self):
+        """들여쓰기된 줄도 두 공백 추가"""
+        from app import format_translation_result
+
+        text = "Normal line\n    Indented line\n        Double indented"
+        result = format_translation_result(text)
+
+        expected = "Normal line  \n    Indented line  \n        Double indented  "
+        assert result == expected
+
+    def test_empty_string(self):
+        """빈 문자열은 빈 문자열 반환"""
+        from app import format_translation_result
+
+        text = ""
+        result = format_translation_result(text)
+
+        assert result == ""
+
+    def test_only_newlines(self):
+        """개행만 있는 경우"""
+        from app import format_translation_result
+
+        text = "\n\n\n"
+        result = format_translation_result(text)
+
+        expected = "\n\n\n"
+        assert result == expected
+
+    def test_markdown_list_preserved(self):
+        """마크다운 리스트 형식이 보존됨"""
+        from app import format_translation_result
+
+        text = "- Item 1\n- Item 2\n- Item 3"
+        result = format_translation_result(text)
+
+        expected = "- Item 1  \n- Item 2  \n- Item 3  "
+        assert result == expected
+
+    def test_code_block_preserved(self):
+        """코드 블록 형식이 보존됨"""
+        from app import format_translation_result
+
+        text = "```python\nprint('hello')\nprint('world')\n```"
+        result = format_translation_result(text)
+
+        expected = "```python  \nprint('hello')  \nprint('world')  \n```  "
+        assert result == expected
 
 
 class TestSetupSidebarOpenAI:


### PR DESCRIPTION
## Summary

번역 결과의 줄바꿈과 들여쓰기를 보존하는 기능을 구현했습니다.

## Changes

### 기능 추가
- **format_translation_result() 헬퍼 함수**: 각 줄 끝에 두 공백을 추가하여 Markdown 줄바꿈 규칙 적용
- **사이드바 옵션**: "📝 포맷 유지" 체크박스 추가 (기본값: True)
- **세션 상태**: preserve_format 추가하여 사용자 설정 저장
- **조건부 렌더링**: render_translation_result()에서 포맷 유지 옵션에 따라 동적으로 처리

### 테스트
- `TestFormatTranslationResult` 클래스에 11개의 단위 테스트 추가
- 다양한 엣지 케이스 커버: 단일/다중 줄, 빈 줄, 공백, 들여쓰기, Markdown 형식 등
- 전체 테스트 스위트: 158 passed
- 코드 커버리지: 99.25% (목표 80% 초과)

## Test Plan

- [x] 단위 테스트 작성 및 실행 (11개 테스트, 100% 통과)
- [x] 전체 테스트 스위트 실행 (158 passed)
- [x] 코드 커버리지 확인 (99.25%)
- [x] Python 문법 체크 통과

## Screenshots

N/A - UI 기능이므로 수동 테스트 권장

## Related Issues

Closes #57

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)